### PR TITLE
On a get request for endpoint 'brew-coffee' add in external request to fetch temperature from external weather API

### DIFF
--- a/BrewCoffeeApi/BrewCoffeeApi/Program.cs
+++ b/BrewCoffeeApi/BrewCoffeeApi/Program.cs
@@ -1,4 +1,6 @@
 using BrewCoffeeApi;
+using Microsoft.Extensions.Logging;
+using System.Text.Json;
 
 
 var builder = WebApplication.CreateBuilder(args);
@@ -17,6 +19,11 @@ static bool IsAprilFoolsDay()
     return DateTime.Today.Month == 4 && DateTime.Today.Day == 1;
 }
 
+static double KelvinToCelsius(double kelvin)
+{
+    return kelvin - 273.15;
+}
+
 app.MapGet("/", () => "Brew Coffee API !");
 
 app.MapGet("/brew-coffee", async (HttpContext context) =>
@@ -25,45 +32,61 @@ app.MapGet("/brew-coffee", async (HttpContext context) =>
 
     int requestCount = RequestCounter.Increment();
 
-    if (requestCount % 5 == 0)
+    if (requestCount % 5 == 0) //every 5 calls reply with service unavailable.
     {
         return Results.StatusCode(503);
     }
     else if (IsAprilFoolsDay())
     {
-        return Results.StatusCode(418);
+        return Results.StatusCode(418); //I'm a teapot
     }
     else
     {
-        //Add here some exception handling because this can easily break.
-
-
-        // Read API key from configuration
-        var configuration = context.RequestServices.GetRequiredService<IConfiguration>();
-        var apiKey = configuration["WeatherApi:ApiKey"];
-
-        if (string.IsNullOrEmpty(apiKey))
+        //exception handling here is pretty basic  - lots can go wrong here. However, we are keeping things simple here, and don't really care what goes wrong.
+        try
         {
-            return Results.StatusCode(500); // Internal Server Error if API key is not set
+
+            // Read API key from configuration
+            var configuration = context.RequestServices.GetRequiredService<IConfiguration>();
+            var apiKey = configuration["WeatherApi:ApiKey"];
+
+            if (string.IsNullOrEmpty(apiKey))
+            {
+                return Results.StatusCode(500); // Internal Server Error if API key is not set
+            }
+
+            var httpClient = httpClientFactory.CreateClient();
+
+            // Define latitude and longitude for Point Cook, Melbourne
+            string latitude = "-37.9142";
+            string longitude = "144.7506";
+
+            // Call OpenWeatherMap API
+            var weatherResponse = await httpClient.GetStringAsync($"https://api.openweathermap.org/data/2.5/weather?lat={latitude}&lon={longitude}&appid={apiKey}");
+
+            // Parse JSON to extract temperature
+            using (JsonDocument document = JsonDocument.Parse(weatherResponse))
+            {
+                double temperature = document.RootElement.GetProperty("main").GetProperty("temp").GetDouble();
+                
+                temperature = KelvinToCelsius(temperature);
+
+                var msg = temperature > 30 ? "Your refreshing iced coffee is ready." : "Your piping hot coffee is ready.";
+
+                var response = new Response
+                {
+                    Message = $"{msg}",
+                    Prepared = GetIso8601Timestamp(),
+               
+                };
+
+                return Results.Json(response);
+            }
+        }         
+        catch
+        {            
+            return Results.StatusCode(500); // Internal Server Error for other exceptions
         }
-
-        var httpClient = httpClientFactory.CreateClient();
-
-        // Define latitude and longitude for Point Cook, Melbourne
-        string latitude = "-37.9142";
-        string longitude = "144.7506";
-
-        // Call OpenWeatherMap API
-        var weatherResponse = await httpClient.GetStringAsync($"https://api.openweathermap.org/data/2.5/weather?lat={latitude}&lon={longitude}&appid={apiKey}");
-
-        var response = new Response
-        {
-            Message = "Your piping hot coffee is ready",
-            Prepared = GetIso8601Timestamp(),
-            //WeatherInfo = weatherResponse
-        };
-
-        return Results.Json(response);
     }
 });
 

--- a/BrewCoffeeApi/BrewCoffeeApi/Program.cs
+++ b/BrewCoffeeApi/BrewCoffeeApi/Program.cs
@@ -1,6 +1,8 @@
 using BrewCoffeeApi;
 
+
 var builder = WebApplication.CreateBuilder(args);
+builder.Services.AddHttpClient();
 var app = builder.Build();
 
 
@@ -15,38 +17,55 @@ static bool IsAprilFoolsDay()
     return DateTime.Today.Month == 4 && DateTime.Today.Day == 1;
 }
 
-
 app.MapGet("/", () => "Brew Coffee API !");
 
-app.MapGet("/brew-coffee", (HttpContext context) =>
+app.MapGet("/brew-coffee", async (HttpContext context) =>
 {
+    var httpClientFactory = context.RequestServices.GetRequiredService<IHttpClientFactory>();
 
     int requestCount = RequestCounter.Increment();
-
 
     if (requestCount % 5 == 0)
     {
         return Results.StatusCode(503);
-         
     }
     else if (IsAprilFoolsDay())
     {
-
         return Results.StatusCode(418);
     }
     else
     {
+        //Add here some exception handling because this can easily break.
+
+
+        // Read API key from configuration
+        var configuration = context.RequestServices.GetRequiredService<IConfiguration>();
+        var apiKey = configuration["WeatherApi:ApiKey"];
+
+        if (string.IsNullOrEmpty(apiKey))
+        {
+            return Results.StatusCode(500); // Internal Server Error if API key is not set
+        }
+
+        var httpClient = httpClientFactory.CreateClient();
+
+        // Define latitude and longitude for Point Cook, Melbourne
+        string latitude = "-37.9142";
+        string longitude = "144.7506";
+
+        // Call OpenWeatherMap API
+        var weatherResponse = await httpClient.GetStringAsync($"https://api.openweathermap.org/data/2.5/weather?lat={latitude}&lon={longitude}&appid={apiKey}");
+
         var response = new Response
         {
             Message = "Your piping hot coffee is ready",
-            Prepared = GetIso8601Timestamp()
+            Prepared = GetIso8601Timestamp(),
+            //WeatherInfo = weatherResponse
         };
 
-        
-        return Results.Json(response); // Returns a 200 OK status with the custom response
+        return Results.Json(response);
     }
 });
-
 
 
 app.Run();

--- a/BrewCoffeeApi/BrewCoffeeApi/Program.cs
+++ b/BrewCoffeeApi/BrewCoffeeApi/Program.cs
@@ -8,23 +8,31 @@ builder.Services.AddHttpClient();
 var app = builder.Build();
 
 
-string GetIso8601Timestamp()
+string MelbourneUTCDateTime()
 {
-    return DateTimeOffset.UtcNow.ToString("o");
+   DateTimeOffset utcNow = DateTimeOffset.UtcNow;
+   TimeZoneInfo melbourneTimeZone = TimeZoneInfo.FindSystemTimeZoneById("AUS Eastern Standard Time");
+
+   DateTimeOffset melbourneTime = TimeZoneInfo.ConvertTime(utcNow, melbourneTimeZone);
+
+   return melbourneTime.ToString("yyyy-MM-ddTHH:mm:sszzz");     
 }
 
-static bool IsAprilFoolsDay()
+bool IsAprilFoolsDay()
 {
-    // Return true if the month is April and the day is 1
-    return DateTime.Today.Month == 4 && DateTime.Today.Day == 1;
+    var today = DateTime.Today;
+    return today.Month == 4 && today.Day == 1;
 }
 
-static double KelvinToCelsius(double kelvin)
+double KelvinToCelsius(double kelvin)
 {
     return kelvin - 273.15;
 }
 
 app.MapGet("/", () => "Brew Coffee API !");
+
+ 
+
 
 app.MapGet("/brew-coffee", async (HttpContext context) =>
 {
@@ -42,7 +50,7 @@ app.MapGet("/brew-coffee", async (HttpContext context) =>
     }
     else
     {
-        //exception handling here is pretty basic  - lots can go wrong here. However, we are keeping things simple here, and don't really care what goes wrong.
+    
         try
         {
 
@@ -76,7 +84,7 @@ app.MapGet("/brew-coffee", async (HttpContext context) =>
                 var response = new Response
                 {
                     Message = $"{msg}",
-                    Prepared = GetIso8601Timestamp(),
+                    Prepared = MelbourneUTCDateTime(),
                
                 };
 
@@ -85,10 +93,11 @@ app.MapGet("/brew-coffee", async (HttpContext context) =>
         }         
         catch
         {            
-            return Results.StatusCode(500); // Internal Server Error for other exceptions
+            return Results.StatusCode(500); 
         }
     }
 });
 
+ 
 
 app.Run();

--- a/BrewCoffeeApi/BrewCoffeeApi/Response.cs
+++ b/BrewCoffeeApi/BrewCoffeeApi/Response.cs
@@ -1,6 +1,7 @@
 ﻿namespace BrewCoffeeApi
 {
      
+
         public class Response
         {
             public string Message { get; set; }

--- a/BrewCoffeeApi/BrewCoffeeApi/appsettings.json
+++ b/BrewCoffeeApi/BrewCoffeeApi/appsettings.json
@@ -1,4 +1,7 @@
 {
+  "WeatherApi": {
+    "ApiKey": "your api key here"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",
@@ -6,4 +9,6 @@
     }
   },
   "AllowedHosts": "*"
+
+
 }


### PR DESCRIPTION
When the endpoint GET /brew-coffee is called, the endpoint should check a third-party  weather service (e.g. https://openweathermap.org/api), and if the current temperature is  greater than 30°C, the returned message should be changed to “Your refreshing iced  coffee is ready”; 

I have removed the extra space in 'iced  coffee'
